### PR TITLE
Feature/resume from tablemap pos

### DIFF
--- a/lib/kodama/client.rb
+++ b/lib/kodama/client.rb
@@ -30,6 +30,7 @@ module Kodama
     def initialize(url)
       @url = url
       @binlog_info = BinlogInfo.new
+      @processed_binlog_info = BinlogInfo.new
       @retry_info = RetryInfo.new(:limit => 100, :wait => 3)
       @callbacks = {}
       @logger = Logger.new(STDOUT)
@@ -52,6 +53,11 @@ module Kodama
     def binlog_position_file=(filename)
       @position_file = position_file(filename)
       @binlog_info.load!(@position_file)
+    end
+
+    def processed_binlog_position_file=(filename)
+      @processed_position_file = position_file(filename)
+      @processed_binlog_info.load!(@processed_position_file)
     end
 
     def connection_retry_wait=(wait)
@@ -137,16 +143,34 @@ module Kodama
     end
 
     def process_event(event)
-      @binlog_info.position = event.next_position
+      # If the position in binlog file is behind the processed position,
+      # keep updating only binlog info
+      unless @binlog_info.should_process?(@processed_binlog_info)
+        case event
+        when Binlog::QueryEvent
+          save_binlog_info(@binlog_info.filename, event.next_position)
+        when Binlog::RotateEvent
+          save_binlog_info(event.binlog_file, event.binlog_pos)
+        end
+        set_next_event_position(@binlog_info, event)
+        return
+      end
+
+      # Keep current binlog position temporary
+      cur_binlog_file = @binlog_info.filename
+      cur_binlog_pos = @binlog_info.position
+
       case event
       when Binlog::QueryEvent
         callback :on_query_event, event
-        @binlog_info.save(@position_file)
+        # Save current event's position as processed (@processed_binlog_info)
+        save_processed_binlog_info(cur_binlog_file, cur_binlog_pos)
+        # Save next event's position as checkpoint (@binlog_info)
+        save_binlog_info(cur_binlog_file, event.next_position)
       when Binlog::RotateEvent
         callback :on_rotate_event, event
-        @binlog_info.filename = event.binlog_file
-        @binlog_info.position = event.binlog_pos
-        @binlog_info.save(@position_file)
+        # Update binlog_info with rotation
+        save_binlog_info(event.binlog_file, event.binlog_pos)
       when Binlog::IntVarEvent
         callback :on_int_var_event, event
       when Binlog::UserVarEvent
@@ -157,9 +181,12 @@ module Kodama
         callback :on_xid, event
       when Binlog::TableMapEvent
         callback :on_table_map_event, event
+        # Save current event's position as checkpoint
+        save_binlog_info(cur_binlog_file, cur_binlog_pos)
       when Binlog::RowEvent
         callback :on_row_event, event
-        @binlog_info.save(@position_file)
+        # Save current event's position as processed
+        save_processed_binlog_info(cur_binlog_file, cur_binlog_pos)
       when Binlog::IncidentEvent
         callback :on_incident_event, event
       when Binlog::UnimplementedEvent
@@ -167,6 +194,9 @@ module Kodama
       else
         @logger.error "Not Implemented: #{event.event_type}"
       end
+
+      # Set the next event position for the next iteration
+      set_next_event_position(@binlog_info, event)
     end
 
     def callback(name, *args)
@@ -175,6 +205,29 @@ module Kodama
       else
         @logger.debug "Unhandled: #{name}"
       end
+    end
+
+    # Set the next event position for the next iteration
+    # Compare positions to avoid decreasing the position unintentionally
+    # because next_position of Binlog::FormatEvent is always 0
+    def set_next_event_position(binlog_info, event)
+      if !event.kind_of?(Binlog::RotateEvent) && binlog_info.position.to_i < event.next_position.to_i
+        binlog_info.position = event.next_position
+      end
+    end
+
+    def save_binlog_info(bin_file = nil, bin_pos = nil)
+      save_binlog_info_to_file(@binlog_info, @position_file, bin_file, bin_pos)
+    end
+
+    def save_processed_binlog_info(bin_file, bin_pos)
+      save_binlog_info_to_file(@processed_binlog_info, @processed_position_file, bin_file, bin_pos)
+    end
+
+    def save_binlog_info_to_file(binlog_info, save_file, bin_file, bin_pos)
+      binlog_info.filename = bin_file if bin_file
+      binlog_info.position = bin_pos if bin_pos
+      binlog_info.save(save_file)
     end
 
     class BinlogInfo
@@ -197,6 +250,29 @@ module Kodama
 
       def load!(position_file)
         @filename, @position = position_file.read
+      end
+
+      def should_process?(processed_binlog_info)
+        if self.valid? && processed_binlog_info && processed_binlog_info.valid?
+          # Compare binlog filename and position
+          #
+          # Event should be processed only when the event position is bigger than
+          # the processed position
+          #
+          #   ex)
+          #   binlog_info               processed_binlog_info     result
+          #   -----------------------------------------------------------
+          #   mysql-bin.000004 00001    mysql-bin.000003 00001    true
+          #   mysql-bin.000004 00030    mysql-bin.000004 00001    true
+          #   mysql-bin.000004 00030    mysql-bin.000004 00030    false
+          #   mysql-bin.000004 00030    mysql-bin.000004 00050    false
+          #   mysql-bin.000004 00030    mysql-bin.000005 00001    false
+          @filename > processed_binlog_info.filename ||
+            (@filename == processed_binlog_info.filename &&
+             @position.to_i > processed_binlog_info.position.to_i)
+        else
+          true
+        end
       end
     end
 

--- a/lib/kodama/client.rb
+++ b/lib/kodama/client.rb
@@ -150,6 +150,8 @@ module Kodama
         when Binlog::QueryEvent
           @binlog_info.save_with(@binlog_info.filename, event.next_position)
         when Binlog::RotateEvent
+          # Call callback because app might need binlog info when resuming
+          callback :on_rotate_event, event
           @binlog_info.save_with(event.binlog_file, event.binlog_pos)
         end
         set_next_event_position(@binlog_info, event)

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -133,7 +133,7 @@ describe Kodama::Client do
       #               100           100          200              250        300
       let(:events) { [rotate_event, query_event, table_map_event, row_event, xid_event] }
 
-      context 'when processed position file is not set' do
+      context 'when sent position file is not set' do
         it 'should save position on events' do
           position_file = TestPositionFile.new.tap do |pf|
             # On rotate event
@@ -149,9 +149,9 @@ describe Kodama::Client do
         end
       end
 
-      context 'when processed position file is set' do
-        context 'when processed position is empty' do
-          it 'should save position and processed position on events' do
+      context 'when sent position file is set' do
+        context 'when sent position is empty' do
+          it 'should save position and sent position on events' do
             position_file = TestPositionFile.new.tap do |pf|
               pf.should_receive(:update).with('binlog', 100).once.ordered
               pf.should_receive(:update).with('binlog', 200).twice.ordered
@@ -160,7 +160,7 @@ describe Kodama::Client do
               pf.should_receive(:update).with('binlog', 400).never
             end
 
-            processed_position_file = TestPositionFile.new.tap do |pf|
+            sent_position_file = TestPositionFile.new.tap do |pf|
               # At query event
               pf.should_receive(:update).with('binlog', 100).once
               pf.should_receive(:update).with('binlog', 200).never
@@ -171,16 +171,16 @@ describe Kodama::Client do
             end
 
             stub_position_files('test_resume' => position_file,
-                                'test_processed' => processed_position_file)
+                                'test_sent' => sent_position_file)
 
             client.binlog_position_file = 'test_resume'
-            client.processed_binlog_position_file = 'test_processed'
+            client.sent_binlog_position_file = 'test_sent'
             client.start
           end
         end
 
-        context 'when processed position is not empty' do
-          it 'should save position and processed position on events' do
+        context 'when sent position is not empty' do
+          it 'should save position and sent position on events' do
             position_file = TestPositionFile.new.tap do |pf|
               pf.should_receive(:update).with('binlog', 100).once.ordered
               pf.should_receive(:update).with('binlog', 200).twice.ordered
@@ -189,7 +189,7 @@ describe Kodama::Client do
               pf.should_receive(:update).with('binlog', 400).never
             end
 
-            processed_position_file = TestPositionFile.new.tap do |pf|
+            sent_position_file = TestPositionFile.new.tap do |pf|
               pf.should_receive(:read).and_return(['binlog', 100])
               # At query event -> shold be skipped
               pf.should_receive(:update).with('binlog', 100).never
@@ -201,10 +201,10 @@ describe Kodama::Client do
             end
 
             stub_position_files('test_resume' => position_file,
-                                'test_processed' => processed_position_file)
+                                'test_sent' => sent_position_file)
 
             client.binlog_position_file = 'test_resume'
-            client.processed_binlog_position_file = 'test_processed'
+            client.sent_binlog_position_file = 'test_sent'
             client.start
           end
         end


### PR DESCRIPTION
This is the bug fix to prevent resuming without table_map event. When the process is down during middle of multiple row events, kodama will resume from the position of row event, which causes missing table map error.

To avoid this, the position file is saved only at the following checkpoints in this change.
- Next position of QueryEvent
- Position at RotateEvent
- Position at TableMapEvent

Also I introduced "sent position file" which stores the latest sent event position(only necessary events) and is used for preventing processing sent events when resuming.

To use this feature, `Kodama::Client#sent_binlog_position_file` needs to be set in start method block. As for compatibility, since this option is optional, kodama will work with old implementation. 

```
Kodama::Client.start(:host => 'localhost', :username => 'root') do |c|
  c.binlog_position_file = 'position.log'
  # Set sent position file path here
  c.sent_binlog_position_file = 'sent_position.log'

  c.on_row_event do |event|
    worker.perform(event)
  end
end
```
