### PR TITLE
Feature/b660 tablemap error

### DIFF
--- a/example/test_client.rb
+++ b/example/test_client.rb
@@ -50,6 +50,7 @@ end
 
 worker = Worker.new
 
+SLEEP_TIME = 3
 puts "===== Kodama client start ====="
 Kodama::Client.start(conn_info) do |c|
   puts conn_info
@@ -62,14 +63,19 @@ Kodama::Client.start(conn_info) do |c|
 
   c.on_row_event do |event|
     worker.perform(event)
-    sleep 1
+    sleep SLEEP_TIME
   end
   c.on_query_event do |event|
     puts "query: #{event.query}"
-    sleep 1
+    sleep SLEEP_TIME
   end
   c.on_rotate_event do |event|
     puts "rotate:#{event.binlog_file} #{event.binlog_pos}"
-    sleep 1
+    sleep SLEEP_TIME
   end
+  c.on_table_map_event do |event|
+    puts "table_map: #{event.table_name}"
+    sleep SLEEP_TIME
+  end
+ 
 end

--- a/lib/kodama/client.rb
+++ b/lib/kodama/client.rb
@@ -208,7 +208,12 @@ module Kodama
           callback :on_table_map_event, event
         end
         # Save current event's position as checkpoint
-        @binlog_info.save_with(cur_binlog_file, cur_binlog_pos)
+
+        # For the case when receiving multiple table map events in a row.
+        # In that case, the resume point needs to be the first table map event position.
+        unless @previous_event.kind_of?(Binlog::TableMapEvent)
+          @binlog_info.save_with(cur_binlog_file, cur_binlog_pos)
+        end
 
       when Binlog::RowEvent
         if processable
@@ -233,6 +238,7 @@ module Kodama
 
       # Set the next event position for the next iteration
       set_next_event_position(@binlog_info, event)
+      @previous_event = event
     end
 
     def callback(name, *args)

--- a/lib/kodama/client.rb
+++ b/lib/kodama/client.rb
@@ -158,6 +158,8 @@ module Kodama
     end
 
     def process_event(event)
+      #puts "(kodama) (resume) cur_pos:#{@binlog_info.filename}/#{@binlog_info.position} next_pos:#{event.next_position} event:#{event}"
+
       # If the position in binlog file is behind the sent position,
       # keep updating only binlog info in most of cases
       processable = @binlog_info.should_process?(@sent_binlog_info)
@@ -279,6 +281,7 @@ module Kodama
 
       def save(position_file = nil)
         @position_file = position_file if position_file
+        #puts "  (pos-file-update) #{@position_file.filename} #{filename} #{position}"
         @position_file.update(@filename, @position) if @position_file
       end
 


### PR DESCRIPTION
"Table map" error occurrs after Kodama stops during a series of multiple "table_map" events. This situation was unexpected, but the table update which has a trigger action causes multiple table map events. 
- How to reproduce multiple table map events

```
create table trigger_table (id int primary key, value varchar(20));
create table trigger_table_2 (id int primary key auto_increment, value int);

create trigger update_trigger_table_2 after insert on trigger_table FOR EACH ROW insert into trigger_table_2 (value) values (id);

insert into trigger_table values (1, 'test');
```
- Binlog

```
# at 1446
#150424 13:29:42 server id 888888  end_log_pos 1506     Table_map: `sync_test`.`trigger_table` mapped to number 102
# at 1506
#150424 13:29:42 server id 888888  end_log_pos 1566     Table_map: `sync_test`.`trigger_table_2` mapped to number 104
# at 1566
#150424 13:29:42 server id 888888  end_log_pos 1605     Write_rows: table id 102
# at 1605
#150424 13:29:42 server id 888888  end_log_pos 1643     Write_rows: table id 104 flags: STMT_END_F
```

In the above case, resume point should be the first table map event position, so I made a change to keep that position. 
