### PR TITLE
Feature/b734 handle overflowed pos

### DIFF
--- a/lib/kodama/client.rb
+++ b/lib/kodama/client.rb
@@ -185,8 +185,10 @@ module Kodama
         # because app might need binlog info when resuming.
         callback :on_rotate_event, event
         # Update binlog_info with rotation
-        @binlog_info.save_with(event.binlog_file, event.binlog_pos)
-        @current_position_overflowed = false
+        if cur_binlog_file != event.binlog_file   # only when binlog file is changed
+          @binlog_info.save_with(event.binlog_file, event.binlog_pos)
+          @current_position_overflowed = false
+        end
 
       when Binlog::IntVarEvent
         if processable

--- a/lib/kodama/client.rb
+++ b/lib/kodama/client.rb
@@ -166,7 +166,7 @@ module Kodama
 
       # Keep current binlog position temporary
       cur_binlog_file = @binlog_info.filename
-      cur_binlog_pos = @binlog_info.position
+      cur_binlog_pos = (@binlog_info.position || 4)  # 4 is the binlog head position
 
       case event
       when Binlog::QueryEvent
@@ -176,7 +176,9 @@ module Kodama
           @sent_binlog_info.save_with(cur_binlog_file, cur_binlog_pos)
         end
         # Save next event's position as checkpoint (@binlog_info)
-        @binlog_info.save_with(cur_binlog_file, event.next_position)
+        unless next_position_overflowed?(cur_binlog_pos, event)
+          @binlog_info.save_with(cur_binlog_file, calc_next_position(cur_binlog_pos, event))
+        end
 
       when Binlog::RotateEvent
         # Even if the event is already sent, call callback
@@ -184,6 +186,7 @@ module Kodama
         callback :on_rotate_event, event
         # Update binlog_info with rotation
         @binlog_info.save_with(event.binlog_file, event.binlog_pos)
+        @current_position_overflowed = false
 
       when Binlog::IntVarEvent
         if processable
@@ -213,7 +216,8 @@ module Kodama
 
         # For the case when receiving multiple table map events in a row.
         # In that case, the resume point needs to be the first table map event position.
-        unless @previous_event.kind_of?(Binlog::TableMapEvent)
+        # Also when current position is overflowed, skip saving binlog for resume.
+        if !@previous_event.kind_of?(Binlog::TableMapEvent) && !@current_position_overflowed
           @binlog_info.save_with(cur_binlog_file, cur_binlog_pos)
         end
 
@@ -239,7 +243,25 @@ module Kodama
       end
 
       # Set the next event position for the next iteration
-      set_next_event_position(@binlog_info, event)
+      set_next_event_position(@binlog_info, cur_binlog_pos, event)
+
+      # Set true to current_position_overflowed flag if the next position is smaller than the current position
+      # If current_position_overflowed is true:
+      #   - binlog pos file for resume will not be updated
+      #   - calculate the next position with event.event_length, not using event.next_event
+      #
+      # binlog format has integer overflow issue for event.next_position and set position api
+      # when the position exceeds 4294967295(4GB).
+      # It can happen when running a large transaction according to mysql docs.
+      # https://dev.mysql.com/doc/refman/5.1/en/replication-options-binary-log.html#sysvar_max_binlog_size
+      #
+      # The issue is that the position larger than 4294967295 cannot be set for resume point
+      # because set_position api doesn't support a larger position. Also the events after 4294967295
+      # were not processed because of small position.
+      if next_position_overflowed?(cur_binlog_pos, event)
+        @current_position_overflowed = true
+      end
+
       @previous_event = event
     end
 
@@ -254,10 +276,29 @@ module Kodama
     # Set the next event position for the next iteration
     # Compare positions to avoid decreasing the position unintentionally
     # because next_position of Binlog::FormatEvent is always 0
-    def set_next_event_position(binlog_info, event)
-      if !event.kind_of?(Binlog::RotateEvent) && binlog_info.position.to_i < event.next_position.to_i
-        binlog_info.position = event.next_position
+    def set_next_event_position(binlog_info, cur_binlog_pos, event)
+      next_position = calc_next_position(cur_binlog_pos, event)
+      if !event.kind_of?(Binlog::RotateEvent) && binlog_info.position.to_i < next_position
+        binlog_info.position = next_position
       end
+    end
+
+    def calc_next_position(cur_binlog_pos, event)
+      # Calculate next position from current position and event length if position is overflowed
+      if next_position_overflowed?(cur_binlog_pos, event)
+        # return 0 when next_position is 0
+        if event.next_position.to_i == 0
+          0
+        else
+          cur_binlog_pos + event.event_length
+        end
+      else
+        event.next_position
+      end
+    end
+
+    def next_position_overflowed?(cur_binlog_pos, event)
+      (event.next_position != 0 && event.next_position < cur_binlog_pos.to_i) || @current_position_overflowed
     end
 
     class BinlogInfo

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -8,9 +8,9 @@ describe Kodama::Client do
     end
 
     it do
-      mysql_url(:username => 'user', :host => 'example.com').should == 'mysql://user@example.com'
-      mysql_url(:username => 'user', :host => 'example.com',
-                :password => 'password', :port => 3306).should == 'mysql://user:password@example.com:3306'
+      expect(mysql_url(:username => 'user', :host => 'example.com')).to eq 'mysql://user@example.com'
+      expect(mysql_url(:username => 'user', :host => 'example.com',
+                       :password => 'password', :port => 3306)).to eq 'mysql://user:password@example.com:3306'
     end
   end
 
@@ -82,7 +82,7 @@ describe Kodama::Client do
          Binlog::TableMapEvent,
         ].each do |event|
           if event == target_event_class
-            event.stub(:===).and_return { true }
+            event.stub(:===).and_return(true)
           else
             # :=== is stubbed
             if event.method(:===).owner != Module
@@ -105,49 +105,49 @@ describe Kodama::Client do
     let(:binlog_client) { TestBinlogClient.new(events, connect) }
 
     def stub_position_file(position_file = nil, file_name = nil)
-      client.stub(:position_file).and_return { position_file || TestPositionFile.new }
+      client.stub(:position_file) { position_file || TestPositionFile.new }
     end
 
     # @param {"file_name" => <PositionFile>, ....}
     def stub_position_files(fn_posf_hash)
-      client.stub(:position_file).and_return { |fn| fn_posf_hash[fn] || TestPositionFile.new }
+      client.stub(:position_file) { |fn| fn_posf_hash[fn] || TestPositionFile.new }
     end
 
     let(:client) {
       c = Kodama::Client.new('mysql://user@host')
-      c.stub(:binlog_client).and_return { binlog_client }
+      c.stub(:binlog_client).and_return(binlog_client)
       c
     }
 
     let(:rotate_event) do
-      mock(Binlog::RotateEvent).tap do |event|
-        event.stub(:next_position).and_return { 0 }
-        event.stub(:binlog_file).and_return { 'binlog' }
-        event.stub(:binlog_pos).and_return { 100 }
+      double(Binlog::RotateEvent).tap do |event|
+        event.stub(:next_position).and_return(0)
+        event.stub(:binlog_file).and_return('binlog')
+        event.stub(:binlog_pos).and_return(100)
       end
     end
 
     let(:query_event) do
-      mock(Binlog::QueryEvent).tap do |event|
-        event.stub(:next_position).and_return { 200 }
+      double(Binlog::QueryEvent).tap do |event|
+        event.stub(:next_position).and_return(200)
       end
     end
 
     let(:table_map_event) do
-      mock(Binlog::TableMapEvent).tap do |event|
-        event.stub(:next_position).and_return { 250 }
+      double(Binlog::TableMapEvent).tap do |event|
+        event.stub(:next_position).and_return(250)
       end
     end
 
     let(:row_event) do
-      mock(Binlog::RowEvent).tap do |event|
-        event.stub(:next_position).and_return { 300 }
+      double(Binlog::RowEvent).tap do |event|
+        event.stub(:next_position).and_return(300)
       end
     end
 
     let(:xid_event) do
-      mock(Binlog::Xid).tap do |event|
-        event.stub(:next_position).and_return { 400 }
+      double(Binlog::Xid).tap do |event|
+        event.stub(:next_position).and_return(400)
       end
     end
 
@@ -258,59 +258,59 @@ describe Kodama::Client do
 
         # 400
         let(:overflowed_table_map_event) do
-          mock(Binlog::TableMapEvent).tap do |event|
-            event.stub(:next_position).and_return { 20 }
-            event.stub(:event_length).and_return { uint_max + 20 - 400 }
+          double(Binlog::TableMapEvent).tap do |event|
+            event.stub(:next_position).and_return(20)
+            event.stub(:event_length).and_return(uint_max + 20 - 400)
           end
         end
 
         # uint_max + 20
         let(:overflowed_row_event) do
-          mock(Binlog::RowEvent).tap do |event|
-            event.stub(:next_position).and_return { 150 }
-            event.stub(:event_length).and_return { 150 - 20 }
+          double(Binlog::RowEvent).tap do |event|
+            event.stub(:next_position).and_return(150)
+            event.stub(:event_length).and_return(150 - 20)
           end
         end
 
         # uint_max + 150
         let(:overflowed_table_map_event_2) do
-          mock(Binlog::TableMapEvent).tap do |event|
-            event.stub(:next_position).and_return { 210 }
-            event.stub(:event_length).and_return { 210 - 150 }
+          double(Binlog::TableMapEvent).tap do |event|
+            event.stub(:next_position).and_return(210)
+            event.stub(:event_length).and_return(210 - 150)
           end
         end
 
         # uint_max + 210
         let(:overflowed_row_event_2) do
-          mock(Binlog::RowEvent).tap do |event|
-            event.stub(:next_position).and_return { 300 }
-            event.stub(:event_length).and_return { 300 - 210 }
+          double(Binlog::RowEvent).tap do |event|
+            event.stub(:next_position).and_return(300)
+            event.stub(:event_length).and_return(300 - 210)
           end
         end
 
         let(:rotate_event_2) do
-          mock(Binlog::RotateEvent).tap do |event|
-            event.stub(:next_position).and_return { 0 }
-            event.stub(:binlog_file).and_return { 'binlog2' }
-            event.stub(:binlog_pos).and_return { 4 }
+          double(Binlog::RotateEvent).tap do |event|
+            event.stub(:next_position).and_return(0)
+            event.stub(:binlog_file).and_return('binlog2')
+            event.stub(:binlog_pos).and_return(4)
           end
         end
 
         let(:query_event_2) do
-          mock(Binlog::QueryEvent).tap do |event|
-            event.stub(:next_position).and_return { 120 }
+          double(Binlog::QueryEvent).tap do |event|
+            event.stub(:next_position).and_return(120)
           end
         end
 
         let(:table_map_event_2) do
-          mock(Binlog::TableMapEvent).tap do |event|
-            event.stub(:next_position).and_return { 180 }
+          double(Binlog::TableMapEvent).tap do |event|
+            event.stub(:next_position).and_return(180)
           end
         end
 
         let(:row_event_2) do
-          mock(Binlog::RowEvent).tap do |event|
-            event.stub(:next_position).and_return { 220 }
+          double(Binlog::RowEvent).tap do |event|
+            event.stub(:next_position).and_return(220)
           end
         end
 


### PR DESCRIPTION
Changes:
- Handle overflowed position
- Skip saving binlog position file with rotate event if the binlog file name is not changed
### Summary

mysqlbinlog format has the integer overflow issue for next event position field. In the huge binlog file, I found the end_log_pos(= next event pos) was reset after 4294864813, which is close to the unique integer max value (4294967295). According to mysql-server docs, only 4 bytes are reserved for the position.

```
log_pos (4) -- position of the next event
```

https://dev.mysql.com/doc/internals/en/binlog-event-header.html

The issues from this limitation were as follows:
- binlog `set_position` doesn't work with the position larger than 4294967295. 
- next position information gets reset after exceeding 4294967295 position
### Approach

Since next_position is used for the sent_position to avoid processing a processed event, we need to calculate the correct next position. Fortunately there is another field "event_length", which enable us to calculate the next position for most of cases. 

However, it cannot be used for some events like format event, I decided to use "event_length" only when the position is overflowed. From these background, I introduced a new notion "current_position_overflowed" and "next_position_overflowed" flag to handle overflowed position data. 

Those flags will be reset when receiving rotate events which changes the binlog file.
