### PR TITLE
Call RubyBinlog::Client#disconnect from #stop_request

### DIFF
--- a/lib/kodama/client.rb
+++ b/lib/kodama/client.rb
@@ -125,6 +125,7 @@ module Kodama
     end
 
     def stop_request
+      @client.disconnect if @client
       @stop_requested = true
     end
 
@@ -155,6 +156,7 @@ module Kodama
       end
 
       begin
+        @client = client
         while event = client.wait_for_next_event
           unsafe do
             process_event(event)
@@ -171,6 +173,7 @@ module Kodama
         raise e
       ensure
         client.disconnect if client
+        @client = nil
       end
     end
 


### PR DESCRIPTION
The original implementation was to call `RubyBinlog#disconnect` after exiting from the main event loop.  With this implementation, however, the process does not finish when the process is SIGTERM'ed until it receives an event from the MySQL server.  This is because `client.wait_for_next_event` blocks the main loop.

In order to stop the process gracefully, the RubyBinlog client must be disconnected from outside of the event loop when the stop request was made.
